### PR TITLE
Bump clang requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,154 +1,36 @@
 name: ci
 on: [push, pull_request]
 jobs:
-  ysyx3:
+  difftest:
     runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        dutName: [ysyx3, rocket, small-boom, large-boom, minimal-xiangshan]
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies
         run: |
-          sudo apt install -y clang llvm flex bison libfl-dev
-      - name: Install verilator
-        run: |
-          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-04-24/oss-cad-suite-linux-x64-20250424.tgz
-          tar xf oss-cad-suite-linux-x64-20250424.tgz
-          OSS_CAD_SUITE_BIN_PATH=`pwd`/oss-cad-suite/bin
-          echo "PATH=$PATH:$OSS_CAD_SUITE_BIN_PATH" >> "$GITHUB_ENV"
-      - name: Check resources
-        run: |
-          echo "nproc = `nproc`"
-          free -h
-          df -h
-          verilator --version
-      - name: Untar linux.bin
-        run: |
-          git submodule set-url ready-to-run https://github.com/jaypiper/gsim-ready-to-run.git
-          make init
-      - name: Run ysyx3 (difftest with verilator)
-        run: |
-          sed -i -e "s/--threads [^ ]*/--threads `nproc`/" Makefile
-          make -j `nproc` diff dutName=ysyx3
-
-  rocket:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+          sudo apt install -y flex bison libfl-dev
+      # Since ubuntu 2404 doesn't comes with llvm >= 19
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
         with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          sudo apt install -y clang llvm flex bison libfl-dev
+            version: "20.1.4"
       - name: Install verilator
-        run: |
-          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-04-24/oss-cad-suite-linux-x64-20250424.tgz
-          tar xf oss-cad-suite-linux-x64-20250424.tgz
-          OSS_CAD_SUITE_BIN_PATH=`pwd`/oss-cad-suite/bin
-          echo "PATH=$PATH:$OSS_CAD_SUITE_BIN_PATH" >> "$GITHUB_ENV"
-      - name: Check resources
-        run: |
-          echo "nproc = `nproc`"
-          free -h
-          df -h
-          verilator --version
-      - name: Untar linux.bin
-        run: |
-          git submodule set-url ready-to-run https://github.com/jaypiper/gsim-ready-to-run.git
-          make init
-      - name: Run rocket (difftest with verilator)
-        run: |
-          sed -i -e "s/--threads [^ ]*/--threads `nproc`/" Makefile
-          make -j `nproc` diff dutName=rocket
-
-  small-boom:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+        uses: YosysHQ/setup-oss-cad-suite@v3
         with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          sudo apt install -y clang llvm flex bison libfl-dev
-      - name: Install verilator
-        run: |
-          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-04-24/oss-cad-suite-linux-x64-20250424.tgz
-          tar xf oss-cad-suite-linux-x64-20250424.tgz
-          OSS_CAD_SUITE_BIN_PATH=`pwd`/oss-cad-suite/bin
-          echo "PATH=$PATH:$OSS_CAD_SUITE_BIN_PATH" >> "$GITHUB_ENV"
-      - name: Check resources
-        run: |
-          echo "nproc = `nproc`"
-          free -h
-          df -h
-          verilator --version
-      - name: Untar linux.bin
-        run: |
-          git submodule set-url ready-to-run https://github.com/jaypiper/gsim-ready-to-run.git
-          make init
-      - name: Run small-boom (difftest with verilator)
-        run: |
-          sed -i -e "s/--threads [^ ]*/--threads `nproc`/" Makefile
-          make -j `nproc` diff dutName=small-boom
-
-  large-boom:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          sudo apt install -y clang llvm flex bison libfl-dev
-      - name: Install verilator
-        run: |
-          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-04-24/oss-cad-suite-linux-x64-20250424.tgz
-          tar xf oss-cad-suite-linux-x64-20250424.tgz
-          OSS_CAD_SUITE_BIN_PATH=`pwd`/oss-cad-suite/bin
-          echo "PATH=$PATH:$OSS_CAD_SUITE_BIN_PATH" >> "$GITHUB_ENV"
-      - name: Check resources
-        run: |
-          echo "nproc = `nproc`"
-          free -h
-          df -h
-          verilator --version
-      - name: Untar linux.bin
-        run: |
-          git submodule set-url ready-to-run https://github.com/jaypiper/gsim-ready-to-run.git
-          make init
-      - name: Run large-boom (difftest with verilator)
-        run: |
-          sed -i -e "s/--threads [^ ]*/--threads `nproc`/" Makefile
-          make -j `nproc` diff dutName=large-boom
-
-  minimal-xiangshan:
-    runs-on: ubuntu-24.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          sudo apt install -y clang llvm flex bison libfl-dev
-      - name: Install verilator
-        run: |
-          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-04-24/oss-cad-suite-linux-x64-20250424.tgz
-          tar xf oss-cad-suite-linux-x64-20250424.tgz
-          OSS_CAD_SUITE_BIN_PATH=`pwd`/oss-cad-suite/bin
-          echo "PATH=$PATH:$OSS_CAD_SUITE_BIN_PATH" >> "$GITHUB_ENV"
+            version: "2025-04-24"
       - name: Enlarge swap
+        if: matrix.dutName == 'minimal-xiangshan'
         run: |
           sudo fallocate -l 60G /mnt/swapfile2
+          sudo chmod 600 /mnt/swapfile2
           sudo mkswap /mnt/swapfile2
           sudo swapon /mnt/swapfile2
       - name: Check resources
@@ -157,45 +39,43 @@ jobs:
           free -h
           df -h
           verilator --version
-      - name: Untar linux.bin
-        run: |
-          git submodule set-url ready-to-run https://github.com/jaypiper/gsim-ready-to-run.git
-          make init
-      - name: Run minimal-xiangshan (difftest with verilator)
+      - name: Untar resources
+        run: make init
+      - name: Run ${{ matrix.dutName }} (difftest with verilator)
         run: |
           sed -i -e "s/--threads [^ ]*/--threads `nproc`/" Makefile
-          make -j `nproc` diff dutName=minimal-xiangshan
+          make -j `nproc` diff dutName=${{ matrix.dutName }}
 
-  ysyx3-bolt:
+
+  bolt-ysyx3:
     runs-on: ubuntu-24.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+        with:
+            submodules: true
+      - uses: actions/setup-python@v5
         with:
           python-version: 3.x
       - name: Install dependencies
         run: |
-          sudo apt install -y clang llvm flex bison libfl-dev llvm-bolt libbolt-dev
-          clang --version
-          llvm-bolt --version
-          sudo ln -s /usr/lib/llvm-18/lib/libbolt_rt_instr.a /usr/lib/libbolt_rt_instr.a
+          sudo apt install -y flex bison libfl-dev
+      # Since ubuntu 2404 doesn't comes with llvm >= 19
+      - name: Install LLVM and Clang
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+            version: "20.1.4"
       - name: Install verilator
-        run: |
-          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-04-24/oss-cad-suite-linux-x64-20250424.tgz
-          tar xf oss-cad-suite-linux-x64-20250424.tgz
-          OSS_CAD_SUITE_BIN_PATH=`pwd`/oss-cad-suite/bin
-          echo "PATH=$PATH:$OSS_CAD_SUITE_BIN_PATH" >> "$GITHUB_ENV"
+        uses: YosysHQ/setup-oss-cad-suite@v3
+        with:
+            version: "2025-04-24"
       - name: Check resources
         run: |
           echo "nproc = `nproc`"
           free -h
           df -h
           verilator --version
-      - name: Untar linux.bin
-        run: |
-          git submodule set-url ready-to-run https://github.com/jaypiper/gsim-ready-to-run.git
-          make init
+      - name: Untar resources
+        run: make init
       - name: Run ysyx3 (with bolt)
         run: |
           sed -i -e "s/--threads [^ ]*/--threads `nproc`/" Makefile

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ GSIM accepts chirrtl, and compiles it to C++
 
 ## Prerequisites
 
-+ Install [GMP](https://gmplib.org/), [clang 16+](https://clang.llvm.org/).
++ Install [GMP](https://gmplib.org/), [clang 19(+)](https://clang.llvm.org/).
 
 ## Quike Start
 

--- a/src/cppEmitter.cpp
+++ b/src/cppEmitter.cpp
@@ -206,13 +206,20 @@ FILE* graph::genHeaderStart() {
                    "} while (0)\n");
   fprintf(header, "#define gdiv(a, b) ((b) == 0 ? 0 : (a) / (b))\n");
 
-  fprintf(header, "#ifndef __BITINT_MAXWIDTH__ // defined by clang\n");
-  fprintf(header, "#error Please compile with clang 16 or above\n");
+  fprintf(header, "#ifndef __BITINT_MAXWIDTH__\n");
+  fprintf(header, "#error  BITINT support is required\n");
+  fprintf(header, "#endif\n\n");
+
+  /* There is some bugs with _BitInt in clang 18 */
+  fprintf(header, "#ifdef __clang__\n");
+  fprintf(header, "#if __clang_major__ < 19\n");
+  fprintf(header, "#error  Please compile with clang 19 or above\n");
   fprintf(header, "#endif\n");
+  fprintf(header, "#endif // __clang__ \n\n");
 
   fprintf(header, "#define likely(x) __builtin_expect(!!(x), 1)\n");
   fprintf(header, "#define unlikely(x) __builtin_expect(!!(x), 0)\n");
-  fprintf(header, "void gprintf(const char *fmt, ...);\n");
+  fprintf(header, "void gprintf(const char *fmt, ...);\n\n");
 
   for (int num = 2; num <= maxConcatNum; num ++) {
     std::string param;


### PR DESCRIPTION
There are some bugs with `_BitInt` in clang 18 causing mini-xs to fail in CI.
So the clang requirement is bumped to >= 19

A clang version check is added in generated header with some minor format change


This PR also refactor the CI configure including:
1. Use matrix to reduce duplicate steps
2. Bump checkout and setup-python version
2-1. Remove manually override submodule path from ssh to https since
checkout with submodules=true takes cares with that
3. Use YosysHQ/setup-oss-cad-suite to install verilator. The verilator
being installed is not bumped for that unvisited edge bug
4. chmod swapfile2 as suggested by mkswap
5. Use 3rd action to install clang since ubuntu 2404 doesn't comes with
llvm >= 19