### PR TITLE
CI: Use GITHUB_TOKEN to prevent API rate limiting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         uses: YosysHQ/setup-oss-cad-suite@v3
         with:
             version: "2025-04-24"
+            github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Enlarge swap
         if: matrix.dutName == 'minimal-xiangshan'
         run: |
@@ -68,6 +69,7 @@ jobs:
         uses: YosysHQ/setup-oss-cad-suite@v3
         with:
             version: "2025-04-24"
+            github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check resources
         run: |
           echo "nproc = `nproc`"


### PR DESCRIPTION
As seen in https://github.com/OpenXiangShan/gsim/actions/runs/16362069080/job/46231816135