### PR TITLE
fix: scope extmodule nodes by instance

### DIFF
--- a/src/AST2Graph.cpp
+++ b/src/AST2Graph.cpp
@@ -547,7 +547,9 @@ void visitExtModule(graph* g, PNode* module) {
     gateAnd->addChild(gateOr);
     Q->valTree = new ExpTree(gateAnd, Q);
   } else {
-    Node* extNode = allocNode(NODE_EXT, module->name, module->lineno);
+    // Extmodule definitions can be instantiated multiple times; keep the
+    // graph node name scoped to this instance and preserve the defname below.
+    Node* extNode = allocNode(NODE_EXT, prefixName(SEP_MODULE, module->name), module->lineno);
     extNode->extraInfo = module->getExtra(0);
     addSignal(extNode->name, extNode);
     PNode* ports = module->getChild(0);


### PR DESCRIPTION
## Summary

Fix extmodule graph node naming so multiple instances of the same extmodule defname do not collide in `allSignals`.

Previously, `visitExtModule()` used `module->name` directly for the `NODE_EXT` name. For extmodules, this can be the external defname, such as `GENERIC_RAM_1P4096D32W16MD`. When the same blackbox definition is instantiated more than once, gsim tries to insert the same signal name into the global `allSignals` map and aborts.

This PR changes the `NODE_EXT` name to use the current instance path via `prefixName(SEP_MODULE, module->name)`, while keeping `extraInfo` as the external defname used for C++ function emission.

## Fixed Error

```text
Signal GENERIC_RAM_1P4096D32W16MD is already in allSignals
gsim: src/AST2Graph.cpp: addSignal(...): Assertion `allSignals.find(s) == allSignals.end()' failed.