### PR TITLE
fix: handle async reset extmodule outputs

### DIFF
--- a/src/cppEmitter.cpp
+++ b/src/cppEmitter.cpp
@@ -543,6 +543,15 @@ int graph::translateInst(InstInfo inst, int indent, std::string flagName) {
 
 void graph::genSuperEval(SuperNode* super, std::string flagName, int indent) { // current indent = 2
   if (super->superType == SUPER_EXTMOD) { // TODO: normalize
+    auto emitExtAsyncReset = [&](Node* extOut) {
+      if (!extOut->isAsyncReset()) return;
+      auto resetId = super2ResetId.find(extOut);
+      Assert(resetId != super2ResetId.end() && resetId->second.second >= 0, "missing async reset id for %s", extOut->name.c_str());
+      emitBodyLock(indent, "subReset%d();\n", resetId->second.second);
+    };
+    for (size_t i = 1; i < super->member.size(); i ++) {
+      emitExtAsyncReset(super->member[i]);
+    }
     /* save old EXT_OUT*/
     for (size_t i = 1; i < super->member.size(); i ++) {
       if (!super->member[i]->needActivate()) continue;
@@ -551,6 +560,9 @@ void graph::genSuperEval(SuperNode* super, std::string flagName, int indent) { /
     }
     for (InstInfo inst : super->insts) {
       indent = translateInst(inst, indent, flagName);
+    }
+    for (size_t i = 1; i < super->member.size(); i ++) {
+      emitExtAsyncReset(super->member[i]);
     }
     for (size_t i = 1; i < super->member.size(); i ++) {
       if (!super->member[i]->needActivate()) continue;

--- a/src/mergeNodes.cpp
+++ b/src/mergeNodes.cpp
@@ -261,8 +261,11 @@ void graph::mergeResetAll() {
     if (asyncSuper->member.size() != 0) {
       allReset.push_back(asyncSuper);
       iter.first->setAsyncReset();
-      iter.first->super->superType = SUPER_ASYNC_RESET;
-      iter.first->super->resetNode = asyncSuper->resetNode;
+      /* Keep special super types such as extmodules on their own emit path. */
+      if (iter.first->super->superType == SUPER_VALID) {
+        iter.first->super->superType = SUPER_ASYNC_RESET;
+        iter.first->super->resetNode = asyncSuper->resetNode;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix scheduling for extmodule outputs that drive async reset signals.

Some extmodules, such as reset synchronizer blackboxes, have outputs typed as async reset. The previous reset merge logic could overwrite an extmodule supernode's type with `SUPER_ASYNC_RESET`, which bypassed the normal `SUPER_EXTMOD` emission path. As a result, the extmodule call and the async reset propagation driven by its outputs could be scheduled incorrectly.

This PR keeps special supernode types such as `SUPER_EXTMOD` on their original emit path, and explicitly emits async reset propagation around extmodule evaluation when extmodule outputs are async reset signals.

## Fixed Behavior

Ensures the following sequence is handled correctly:

```text
extmodule output changes async reset
  -> gsim evaluates the extmodule
  -> dependent async reset logic is propagated