### PR TITLE
build: allow gsim itself to be built with profile guided optimisation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -354,7 +354,7 @@ pgo-gsim:
 	$(GSIM_BIN) $(GSIM_FLAGS) --dir $(GEN_CPP_DIR) $(GSIM_FLAGS_EXTRA) $(FIRRTL_FILE)
 	$(LLVM_PROFDATA) merge -o $(GSIM_PGO_DIR)/gsim.profdata $(GSIM_PGO_DIR)/*.profraw
 	rm -rf $(GSIM_BUILD_DIR)
-	$(MAKE) build-gsim GSIM_PGO_CFLAGS="-fprofile-use=$(GSIM_PGO_DIR)/gsim.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date"
+	$(MAKE) build-gsim GSIM_PGO_CFLAGS="-fprofile-use=$(GSIM_PGO_DIR)/gsim.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -Wno-backend-plugin"
 
 .PHONY: pgo-gsim
 

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ GSIM_INC_DIR = include $(PARSER_DIR)/include $(PARSER_BUILD_DIR)
 # 2) If you still see "DWARF error: invalid or unhandled FORM value: 0x25" from ld
 #    your binutils (ld) may be older than the DWARF version emitted by clang-19.
 #    You can force DWARF v4 by building with: make DWARF4=1 ... (see conditional below).
-CXXFLAGS += -ggdb -O3 -MMD $(addprefix -I,$(GSIM_INC_DIR)) -Wall -Werror --std=c++17 -pthread
+CXXFLAGS += -ggdb -O3 -MMD $(addprefix -I,$(GSIM_INC_DIR)) -Wall -Werror --std=c++17 -pthread $(GSIM_PGO_CFLAGS)
 
 GSIM_VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo UNKNOWN)
 GSIM_BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo UNKNOWN)
@@ -341,6 +341,22 @@ run-veri: $(VERI_BIN)
 
 LLVM_PROFDATA = llvm-profdata
 PGO_BUILD_DIR = $(WORK_DIR)/pgo
+
+# The same treatment for gsim itself. It is branch heavy and chases pointers,
+# so knowing which way the branches actually go is worth more than any single
+# flag. Train on the design given in FIRRTL_FILE.
+GSIM_PGO_DIR = $(BUILD_DIR)/gsim-pgo
+
+pgo-gsim:
+	rm -rf $(GSIM_PGO_DIR) $(GSIM_BUILD_DIR)
+	mkdir -p $(GSIM_PGO_DIR)
+	$(MAKE) build-gsim GSIM_PGO_CFLAGS="-fprofile-generate=$(GSIM_PGO_DIR)"
+	$(GSIM_BIN) $(GSIM_FLAGS) --dir $(GEN_CPP_DIR) $(GSIM_FLAGS_EXTRA) $(FIRRTL_FILE)
+	$(LLVM_PROFDATA) merge -o $(GSIM_PGO_DIR)/gsim.profdata $(GSIM_PGO_DIR)/*.profraw
+	rm -rf $(GSIM_BUILD_DIR)
+	$(MAKE) build-gsim GSIM_PGO_CFLAGS="-fprofile-use=$(GSIM_PGO_DIR)/gsim.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date"
+
+.PHONY: pgo-gsim
 
 pgo:
 	rm -rf $(PGO_BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -339,22 +339,28 @@ run-veri: $(VERI_BIN)
 ### PGO
 ##############################################
 
-LLVM_PROFDATA = llvm-profdata
+# llvm-profdata must match the clang that CXX resolves to; -print-prog-name
+# returns the tool shipped with that compiler, and LLVM_PROFDATA stays
+# overridable on the command line.
+LLVM_PROFDATA ?= $(shell $(CXX) -print-prog-name=llvm-profdata 2>/dev/null || echo llvm-profdata)
 PGO_BUILD_DIR = $(WORK_DIR)/pgo
 
 # The same treatment for gsim itself. It is branch heavy and chases pointers,
 # so knowing which way the branches actually go is worth more than any single
-# flag. Train on the design given in FIRRTL_FILE.
+# flag. Train on the design given in FIRRTL_FILE. Do not run this target
+# concurrently with other goals that consume build/gsim: it removes and
+# rebuilds that directory.
 GSIM_PGO_DIR = $(BUILD_DIR)/gsim-pgo
 
 pgo-gsim:
-	@test -f $(FIRRTL_FILE) || { echo "error: $(FIRRTL_FILE) not found; run 'make init' to fetch the reference designs"; exit 1; }
+	@test -f "$(FIRRTL_FILE)" || { echo "Missing FIRRTL input: $(FIRRTL_FILE). Run 'make init' or pass FIRRTL_FILE=... / dutName=..." >&2; exit 2; }
 	rm -rf $(GSIM_PGO_DIR) $(GSIM_BUILD_DIR)
-	mkdir -p $(GSIM_PGO_DIR)
+	mkdir -p $(GSIM_PGO_DIR) $(GEN_CPP_DIR)
 	$(MAKE) build-gsim GSIM_PGO_CFLAGS="-fprofile-generate=$(GSIM_PGO_DIR)"
-	mkdir -p $(GEN_CPP_DIR)
-	$(GSIM_BIN) $(GSIM_FLAGS) --dir $(GEN_CPP_DIR) $(GSIM_FLAGS_EXTRA) $(FIRRTL_FILE)
-	$(LLVM_PROFDATA) merge -o $(GSIM_PGO_DIR)/gsim.profdata $(GSIM_PGO_DIR)/*.profraw
+	LLVM_PROFILE_FILE="$(GSIM_PGO_DIR)/gsim-%m.profraw" $(GSIM_BIN) $(GSIM_FLAGS) --dir $(GEN_CPP_DIR) $(GSIM_FLAGS_EXTRA) $(FIRRTL_FILE)
+	@shopt -s nullglob; profiles=("$(GSIM_PGO_DIR)"/*.profraw); \
+	(($${#profiles[@]})) || { echo "error: no PGO profiles produced by the training run" >&2; exit 1; }; \
+	"$(LLVM_PROFDATA)" merge -o "$(GSIM_PGO_DIR)/gsim.profdata" "$${profiles[@]}"
 	rm -rf $(GSIM_BUILD_DIR)
 	$(MAKE) build-gsim GSIM_PGO_CFLAGS="-fprofile-use=$(GSIM_PGO_DIR)/gsim.profdata -Wno-profile-instr-unprofiled -Wno-profile-instr-out-of-date -Wno-backend-plugin"
 

--- a/Makefile
+++ b/Makefile
@@ -348,9 +348,11 @@ PGO_BUILD_DIR = $(WORK_DIR)/pgo
 GSIM_PGO_DIR = $(BUILD_DIR)/gsim-pgo
 
 pgo-gsim:
+	@test -f $(FIRRTL_FILE) || { echo "error: $(FIRRTL_FILE) not found; run 'make init' to fetch the reference designs"; exit 1; }
 	rm -rf $(GSIM_PGO_DIR) $(GSIM_BUILD_DIR)
 	mkdir -p $(GSIM_PGO_DIR)
 	$(MAKE) build-gsim GSIM_PGO_CFLAGS="-fprofile-generate=$(GSIM_PGO_DIR)"
+	mkdir -p $(GEN_CPP_DIR)
 	$(GSIM_BIN) $(GSIM_FLAGS) --dir $(GEN_CPP_DIR) $(GSIM_FLAGS_EXTRA) $(FIRRTL_FILE)
 	$(LLVM_PROFDATA) merge -o $(GSIM_PGO_DIR)/gsim.profdata $(GSIM_PGO_DIR)/*.profraw
 	rm -rf $(GSIM_BUILD_DIR)


### PR DESCRIPTION
gsim compiles a FIRRTL design to C++. It is branch-heavy and pointer-chasing,
so branch-prediction hints from a real profile are worth more than any single
compiler flag. This adds a `pgo-gsim` target that:

1. builds gsim with `-fprofile-generate`,
2. runs it once over a training design (`FIRRTL_FILE`, default
   `ready-to-run/$(TEST_FILE).fir`, populated by `make init`), collecting a
   `.profraw`,
3. merges the profile with `llvm-profdata` and rebuilds with `-fprofile-use`.

Usage:

    make pgo-gsim dutName=rocket
    # or point at any design:
    make pgo-gsim FIRRTL_FILE=/path/to/design.fir