### PR TITLE
chore(nix): static build & jemalloc

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,7 @@
             buildInputs = [
               pkgs.flex
               pkgs.gmp
+              pkgs.jemalloc
             ];
 
             makeFlags = [
@@ -60,6 +61,7 @@
               pname = "${prev.pname}-static";
               buildInputs = prev.buildInputs ++ [
                 pkgs.pkgsStatic.gmp
+                pkgs.pkgsStatic.jemalloc
                 llvm.stdenv.cc.libc.static
               ];
               makeFlags = prev.makeFlags ++ [

--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,16 @@
         {
           packages = {
             gsim = gsim;
+            gsim-static = (gsim.overrideAttrs (prev: {
+              pname = "${prev.pname}-static";
+              buildInputs = prev.buildInputs ++ [
+                pkgs.pkgsStatic.gmp
+                llvm.stdenv.cc.libc.static
+              ];
+              makeFlags = prev.makeFlags ++ [
+                "STATIC=1"
+              ];
+            }));
             default = gsim;
           };
         }


### PR DESCRIPTION
1. provide gsim-static build target for portable binary, run `nix build .#gsim-static` to build
2. use jemalloc as default allocator following #116 