### PR TITLE
feat: add --threads option to set the parser worker count

### DIFF
--- a/include/common.h
+++ b/include/common.h
@@ -21,7 +21,6 @@
 #include <gmp.h>
 #include <cstdarg>
 
-#define NR_THREAD 10
 #define ORDERED_TOPO_SORT
 // #define PERF
 

--- a/include/config.h
+++ b/include/config.h
@@ -15,6 +15,7 @@ struct Config {
   int MergeWhenSize;
   int When2muxBound;
   int LogLevel;
+  int NumThreads;
   std::set<std::string> DumpStages;
   Config();
 };

--- a/src/firParser.cpp
+++ b/src/firParser.cpp
@@ -93,7 +93,8 @@ void parseFunc(char *strbuf, int tid) {
 
 PNode* parseFIR(char *strbuf) {
   taskQueue = new std::vector<TaskRecord>;
-  std::future<void> *threads = new std::future<void> [NR_THREAD];
+  const int nrThread = globalConfig.NumThreads;
+  std::future<void> *threads = new std::future<void> [nrThread];
 
   // create tasks
   char *prev = strbuf;
@@ -134,9 +135,9 @@ PNode* parseFIR(char *strbuf) {
     }
   }
   printf("[Parser] using %d threads to parse %d modules with %d tasks\n",
-      NR_THREAD, modules, id);
+      nrThread, modules, id);
   lists = new PList* [id];
-  for (int i = 0; i < NR_THREAD; i ++) {
+  for (int i = 0; i < nrThread; i ++) {
     taskQueue->push_back(TaskRecord{0, 0, -1, -1}); // exit flags
   }
 
@@ -145,12 +146,12 @@ PNode* parseFIR(char *strbuf) {
       [](TaskRecord &a, TaskRecord &b){ return a.len < b.len; });
 
   // create threads
-  for (int i = 0; i < NR_THREAD; i ++) {
+  for (int i = 0; i < nrThread; i ++) {
     threads[i] = async(std::launch::async, parseFunc, strbuf, i);
   }
 
-  for (int i = 0; i < NR_THREAD; i ++) {
-    printf("[Parser] waiting for thread %d/%d...\n", i, NR_THREAD - 1);
+  for (int i = 0; i < nrThread; i ++) {
+    printf("[Parser] waiting for thread %d/%d...\n", i, nrThread - 1);
     threads[i].get();
   }
   assert(taskQueue->empty());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,7 @@ Config::Config() {
   MergeWhenSize = 5;
   When2muxBound = 2;
   LogLevel = 0;
+  NumThreads = 10;
 }
 Config globalConfig;
 
@@ -110,6 +111,7 @@ static void printUsage(const char* ProgName) {
             << "      --when-size=[num]            Bound for merging nested when blocks (default: 5).\n"
             << "      --when2mux-bound=[num]       Bound for converting when to mux (default: 2).\n"
             << "      --log-level=[0|1|2]          Verbosity for additional logs.\n"
+            << "      --threads=[num]              Number of worker threads used to parse the input (default: 10).\n"
             << "      --dump-json                  Dump graphs in JSON (disable dot unless --dump-dot is also set).\n"
             << "      --dump-dot                   Dump graphs in DOT (disable json unless --dump-json is also set).\n"
             << "      --dump-stages=a,b,c          Dump only the listed stages (e.g., Init,TopoSort,AliasAnalysis).\n"
@@ -138,6 +140,7 @@ static char* parseCommandLine(int argc, char** argv) {
     OPT_WHEN_SIZE,
     OPT_WHEN2MUX,
     OPT_LOG_LEVEL,
+    OPT_THREADS,
     OPT_DUMP_JSON,
     OPT_DUMP_DOT,
     OPT_DUMP_STAGES,
@@ -157,6 +160,7 @@ static char* parseCommandLine(int argc, char** argv) {
       {"when-size", required_argument, nullptr, 0},
       {"when2mux-bound", required_argument, nullptr, 0},
       {"log-level", required_argument, nullptr, 0},
+      {"threads", required_argument, nullptr, 0},
       {"dump-json", no_argument, nullptr, 0},
       {"dump-dot", no_argument, nullptr, 0},
       {"dump-stages", required_argument, nullptr, 0},
@@ -186,6 +190,16 @@ static char* parseCommandLine(int argc, char** argv) {
                 case OPT_WHEN_SIZE: sscanf(optarg, "%d", &globalConfig.MergeWhenSize); break;
                 case OPT_WHEN2MUX: sscanf(optarg, "%d", &globalConfig.When2muxBound); break;
                 case OPT_LOG_LEVEL: sscanf(optarg, "%d", &globalConfig.LogLevel); break;
+                case OPT_THREADS:
+                  /* Fewer than one worker leaves the parser tasks unclaimed. */
+                  if (sscanf(optarg, "%d", &globalConfig.NumThreads) != 1 || globalConfig.NumThreads < 1) {
+                    fprintf(stderr, "Error: --threads expects a positive number, got '%s'.\n", optarg);
+                    printUsage(argv[0]);
+                    std::cout.flush();
+                    fflush(nullptr);
+                    _exit(EXIT_FAILURE);
+                  }
+                  break;
                 case OPT_DUMP_JSON:
                   if (explicitDot) {
                     fprintf(stderr, "Error: --dump-json and --dump-dot cannot be used together.\n");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,7 +9,9 @@
 #include "graph.h"
 
 #include <sstream>
+#include <thread>
 #include <getopt.h>
+#include <sched.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <fcntl.h>
@@ -32,6 +34,27 @@ void preorder_traversal(PNode* root);
 graph* AST2Graph(PNode* root);
 void inferAllWidth();
 
+/* The CPUs this process may actually run on. The affinity mask is what a
+   shared or batch scheduled host grants, which can be far less than the
+   machine holds; hardware_concurrency() covers the case where the mask cannot
+   be read, and zero means the limit is unknown. */
+static int availableThreads() {
+  cpu_set_t affinity;
+  if (sched_getaffinity(0, sizeof(affinity), &affinity) == 0) {
+    int usable = CPU_COUNT(&affinity);
+    if (usable > 0) return usable;
+  }
+  return (int)std::thread::hardware_concurrency();
+}
+
+/* Workers past that limit only contend for the same cores, so the requested
+   count is held down to it whenever the limit is known. */
+static int capThreads(int requested) {
+  int limit = availableThreads();
+  if (limit > 0 && requested > limit) return limit;
+  return requested;
+}
+
 Config::Config() {
   EnableDumpGraph = false;
   DumpGraphDot = false;
@@ -46,7 +69,7 @@ Config::Config() {
   MergeWhenSize = 5;
   When2muxBound = 2;
   LogLevel = 0;
-  NumThreads = 10;
+  NumThreads = capThreads(10);
 }
 Config globalConfig;
 
@@ -111,7 +134,8 @@ static void printUsage(const char* ProgName) {
             << "      --when-size=[num]            Bound for merging nested when blocks (default: 5).\n"
             << "      --when2mux-bound=[num]       Bound for converting when to mux (default: 2).\n"
             << "      --log-level=[0|1|2]          Verbosity for additional logs.\n"
-            << "      --threads=[num]              Number of worker threads used to parse the input (default: 10).\n"
+            << "      --threads=[num]              Number of worker threads used to parse the input\n"
+            << "                                   (default: 10, held down to the available CPUs).\n"
             << "      --dump-json                  Dump graphs in JSON (disable dot unless --dump-dot is also set).\n"
             << "      --dump-dot                   Dump graphs in DOT (disable json unless --dump-json is also set).\n"
             << "      --dump-stages=a,b,c          Dump only the listed stages (e.g., Init,TopoSort,AliasAnalysis).\n"
@@ -190,16 +214,23 @@ static char* parseCommandLine(int argc, char** argv) {
                 case OPT_WHEN_SIZE: sscanf(optarg, "%d", &globalConfig.MergeWhenSize); break;
                 case OPT_WHEN2MUX: sscanf(optarg, "%d", &globalConfig.When2muxBound); break;
                 case OPT_LOG_LEVEL: sscanf(optarg, "%d", &globalConfig.LogLevel); break;
-                case OPT_THREADS:
+                case OPT_THREADS: {
+                  int requested = 0;
                   /* Fewer than one worker leaves the parser tasks unclaimed. */
-                  if (sscanf(optarg, "%d", &globalConfig.NumThreads) != 1 || globalConfig.NumThreads < 1) {
+                  if (sscanf(optarg, "%d", &requested) != 1 || requested < 1) {
                     fprintf(stderr, "Error: --threads expects a positive number, got '%s'.\n", optarg);
                     printUsage(argv[0]);
                     std::cout.flush();
                     fflush(nullptr);
                     _exit(EXIT_FAILURE);
                   }
+                  globalConfig.NumThreads = capThreads(requested);
+                  if (globalConfig.NumThreads != requested) {
+                    fprintf(stderr, "Warning: --threads=%d exceeds the %d CPUs available here, using %d.\n",
+                        requested, globalConfig.NumThreads, globalConfig.NumThreads);
+                  }
                   break;
+                }
                 case OPT_DUMP_JSON:
                   if (explicitDot) {
                     fprintf(stderr, "Error: --dump-json and --dump-dot cannot be used together.\n");


### PR DESCRIPTION
Add `--threads=[num]` to control how many workers the FIRRTL parser uses.

  The parser spawned a fixed ten workers, baked into `NR_THREAD`, so a large
  host could not use its cores and a small or shared one could not be told to
  back off. The count now lives in `Config` next to the other compile options.

  The default remains ten, so an unmodified invocation behaves exactly as
  before. A count below one is rejected up front: no worker would claim the
  queued parse tasks, and the parser would wait on them forever.
