### PR TITLE
perf(codegen): emit a block copy for single-dimension array assignments

### DIFF
--- a/src/instsGenerator.cpp
+++ b/src/instsGenerator.cpp
@@ -132,6 +132,67 @@ static std::string constantAssign(std::string lvalue, int dimIdx, Node* node, va
   return ret;
 }
 
+/* Characters that may appear in a generated node name. */
+static bool isArrayNameChar(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+         (c >= '0' && c <= '9') || c == '_' || c == '$';
+}
+
+/* Whether an array expression is rooted at the given name. The leading
+   identifier of an expression names the model member it accesses, so two
+   expressions rooted at different names cannot overlap. */
+static bool hasArrayRoot(const std::string& expr, const std::string& name) {
+  if (expr.compare(0, name.length(), name) != 0) return false;
+  return expr.length() == name.length() || !isArrayNameChar(expr[name.length()]);
+}
+
+/* Strip the trailing loop-index suffix from an rvalue. Returns the base array
+   expression when the rvalue is a bare name optionally followed by constant
+   indices, and an empty string for anything else. */
+static std::string arraySrcBase(const std::string& rvalue, const std::string& idxStr) {
+  if (rvalue.length() <= idxStr.length()) return "";
+  if (rvalue.compare(rvalue.length() - idxStr.length(), idxStr.length(), idxStr) != 0) return "";
+  std::string base = rvalue.substr(0, rvalue.length() - idxStr.length());
+  size_t idx = 0;
+  while (idx < base.length() && isArrayNameChar(base[idx])) idx ++;
+  if (idx == 0) return "";
+  while (idx < base.length()) {
+    if (base[idx ++] != '[') return "";
+    size_t digits = 0;
+    while (idx < base.length() && base[idx] >= '0' && base[idx] <= '9') { idx ++; digits ++; }
+    if (digits == 0 || idx >= base.length() || base[idx ++] != ']') return "";
+  }
+  return base;
+}
+
+/* An element-wise copy loop per array assignment leaves the C++ compiler with a
+   basic block per assignment, and its value numbering scans those blocks
+   superlinearly. Return a single block copy when it is provably equivalent to
+   the loop it replaces, and an empty string otherwise. */
+static std::string arrayBlockCopy(const std::string& lvalue, Node* node, valInfo* rinfo,
+                                  int dimIdx, const std::string& idxStr, int num) {
+  /* Only the innermost dimension is guaranteed contiguous: every declared extent
+     is rounded up to a power of two when the node is defined, so the rows of an
+     outer dimension are not adjacent once that dimension is padded. The element
+     count is taken from the dimension rather than from sizeof of the whole
+     array, which keeps a prefix copy exact. */
+  if (node->dimension.size() - dimIdx != 1) return "";
+  /* The declared element type is described by node->width only when the lvalue
+     really denotes this node. A memory write reaches here with an lvalue rooted
+     at the memory array while node is the writer port. */
+  if (!hasArrayRoot(lvalue, node->name)) return "";
+  std::string src = arraySrcBase(rinfo->valStr, idxStr);
+  if (src.length() == 0) return "";
+  /* A block copy is undefined on overlapping regions. A source rooted at
+     another name is a separate member and cannot overlap the destination. */
+  if (hasArrayRoot(src, node->name)) return "";
+  /* An element assignment converts the source to the destination type, a block
+     copy does not, so both must be declared with the same type. */
+  if (widthBits(node->width) != widthBits(rinfo->width)) return "";
+  return format("memcpy(%s, %s, %d * sizeof(%s[0]));",
+                lvalue.c_str(), src.c_str(), num, lvalue.c_str());
+}
+
 static std::string arrayCopy(std::string lvalue, Node* node, valInfo* rinfo, int dimIdx = -1) {
   std::string ret;
   int num = 1;
@@ -153,12 +214,17 @@ static std::string arrayCopy(std::string lvalue, Node* node, valInfo* rinfo, int
   } else {
     std::string idxStr, bracket;
     for (size_t i = 0; i < node->dimension.size() - dimIdx; i ++) {
-      ret += format("for(int i%ld = 0; i%ld < %d; i%ld ++) { ", i, i, node->dimension[i + dimIdx], i);
       idxStr += "[i" + std::to_string(i) + "]";
-      bracket += "}";
     }
-    ret += format("%s%s = %s; ", lvalue.c_str(), idxStr.c_str(), rinfo->valStr.c_str());
-    ret += bracket;
+    ret = arrayBlockCopy(lvalue, node, rinfo, dimIdx, idxStr, num);
+    if (ret.length() == 0) {
+      for (size_t i = 0; i < node->dimension.size() - dimIdx; i ++) {
+        ret += format("for(int i%ld = 0; i%ld < %d; i%ld ++) { ", i, i, node->dimension[i + dimIdx], i);
+        bracket += "}";
+      }
+      ret += format("%s%s = %s; ", lvalue.c_str(), idxStr.c_str(), rinfo->valStr.c_str());
+      ret += bracket;
+    }
   }
   return ret;
 }


### PR DESCRIPTION
## Problem

gsim emits every array assignment as an element-wise C++ loop. That gives clang a basic block per assignment, and its value numbering scans those blocks superlinearly. On the DefaultConfig XiangShan model one generated file, `SimTop3.cpp`, cost **1318 s** at `-O3` — nearly all of it `GVNPass` — while no other file exceeded 244 s. That single file was the critical path of the model build.

## Change

The fall-through branch of `arrayCopy` gains an eligibility check: emit one `memcpy` where a block copy is provably equivalent to the loop it replaces. Every other case keeps the existing loop emission, and the constant-source paths (`memset` for zero fill, per-element assignment for mixed constants) are untouched.

Four conditions must all hold:

1. **Single dimension.** Declared extents are rounded up to a power of two, so rows of a padded outer dimension are not adjacent. Only the innermost dimension is guaranteed contiguous. The element count comes from `node->dimension` rather than `sizeof` of the whole array, which keeps a prefix copy exact — a 10-entry vec in a `[16]` array copies 10 elements, not 16.
2. **The lvalue denotes this node.** `node->width` describes the destination's declared element type only then. A memory write reaches `arrayCopy` with an lvalue rooted at the memory array while `node` is the writer port.
3. **Plain array source, rooted elsewhere.** The rvalue must be a bare name, optionally followed by constant indices, followed by the loop-index suffix. A different leading identifier proves source and destination are separate members, so the regions cannot overlap.
4. **Matching element type.** An element assignment converts the source to the destination type; a block copy does not.

## Results

Measured on the DefaultConfig XiangShan model, clang 19.1.1, `-O3 -fbracket-depth=2048 -Wno-parentheses-equality -DGSIM`. Both trees generated from one frozen `SimTop.fir` by binaries built from the same worktree.

| | before | after |
|---|---|---|
| `SimTop3.cpp` | **1318.0 s** | **15.5 s** (85x) |
| slowest file overall | 1318.0 s | 239.1 s |
| whole model, compile CPU | 4529 s | 2736 s |

The new slowest file, `SimTop1.cpp`, holds only the `set_*` accessors — no `memcpy`, no `subStep` — and costs 243.6 s before vs 239.1 s after. Its profile is 99.2% `MemCpyOptPass` and 0.0% GVN: a separate pre-existing bottleneck, out of scope here.

## Verification

**Generated code.** 1947 single-dimension copy loops become block copies with none left over; the 1279 multi-dimension loops are unchanged in both trees. Every emitted call parses as `memcpy(DST, SRC, N * sizeof(DST[0]))` with the `sizeof` operand equal to the destination and no shared roots.

**Behaviour.** Two emus built from the two trees, run on coremark for 350 000 instructions at seed 1234 under difftest against NEMU: the 24 651-line logs are identical — same `instrCnt = 350,001`, `cycleCnt = 272,157`, `IPC = 1.286026`, same full PERF dump, both clean. Host time 136.36 s vs 136.31 s, so no throughput change; `.text` grows 0.015%.

A FIRRTL microtest additionally exercises each guard directly — single-dimension register commits, whole-vec copies, 2-D copies (loops kept), and a width-mismatched copy (correctly falls back to the loop) — with identical output digests over 200 000 cycles.

## Note for reviewers

Two comparisons in this area are easy to get wrong, so worth recording. gsim is not run-to-run deterministic: two runs of the same binary on the same input differ in 6 `.cpp` files and reorder a few header declarations. And the linked allocator changes node ordering, so an A/B must use binaries from the same build config. The residual between the two trees here is the same scale as the residual between two identical baseline runs, and neither contains a single copy statement.

The eligibility test pattern-matches the rendered rvalue rather than the expression tree. That is deliberate: `valInfo` carries no back-pointer to a source `Node`, and objects are mutated in place when an expression gets wrapped in a mask or cast, so a stored pointer would go stale exactly where it matters. The string check is self-validating — any wrapping makes the pattern fail and the loop is emitted instead — and matches the existing idiom in this file (`countArrayIndex`, `isSubArray`).

via [HAPI](https://hapi.run)