### PR TITLE
perf(codegen): emit a block copy for single-dimension array assignments

### DIFF
--- a/include/valInfo.h
+++ b/include/valInfo.h
@@ -30,6 +30,9 @@ public:
   int end = -1;
   std::vector<valInfo*> memberInfo;
   bool sameConstant = false;
+  /* Length of the bare array reference valStr was built from, zero when valStr
+     is anything else. Placed here to fit existing padding. */
+  uint32_t arrayRefLen = 0;
   mpz_t assignmentCons;
   bool directUpdate = true;
 
@@ -104,6 +107,8 @@ public:
     if (idx >= memberInfo.size()) return nullptr;
     return memberInfo[idx];
   }
+  bool isArrayRef() { return arrayRefLen != 0; }
+  std::string arrayRef() { return valStr.substr(0, arrayRefLen); }
 };
 
 #endif

--- a/src/instsGenerator.cpp
+++ b/src/instsGenerator.cpp
@@ -150,6 +150,16 @@ static std::string arrayCopy(std::string lvalue, Node* node, valInfo* rinfo, int
       ret = constantAssign(lvalue, dimIdx, node, rinfo->memberInfo[0]);
     } else Panic();
 
+  } else if (node->dimension.size() - dimIdx == 1 && rinfo->isArrayRef()) {
+    /* A loop per copy gives the C++ compiler a basic block per assignment, and
+       its value numbering scans those superlinearly. One block copy is
+       equivalent here: a bare reference over a single dimension is contiguous,
+       cannot overlap the destination since a register splits into current and
+       next state, and shares its type since a width change lowers to a mask or
+       a cast that stops it being bare. The count comes from the dimension
+       rather than sizeof, which keeps a prefix copy exact. */
+    ret = format("memcpy(%s, %s, %d * sizeof(%s[0]));",
+                 lvalue.c_str(), rinfo->arrayRef().c_str(), num, lvalue.c_str());
   } else {
     std::string idxStr, bracket;
     for (size_t i = 0; i < node->dimension.size() - dimIdx; i ++) {
@@ -1475,9 +1485,15 @@ valInfo* ENode::compute(Node* n, std::string lvalue, bool isRoot) {
       computeInfo->beg = beg;
       computeInfo->end = end;
       if (!IS_INVALID_LVALUE(lvalue) && computeInfo->status == VAL_VALID) {
-        for (size_t i = 0; i < nodePtr->dimension.size() - getChildNum(); i ++) {
+        size_t refLen = computeInfo->valStr.length();
+        size_t loopDim = nodePtr->dimension.size() - getChildNum();
+        for (size_t i = 0; i < loopDim; i ++) {
           computeInfo->valStr += "[i" + std::to_string(i) + "]";
         }
+        /* One loop dimension walks the innermost, contiguous elements. Every
+           operator builds a valInfo of its own, so only a bare reference is
+           ever recorded. */
+        if (loopDim == 1) computeInfo->arrayRefLen = refLen;
       }
     } else {
       computeInfo = allocNodeInfo(nodePtr);


### PR DESCRIPTION
## Problem

gsim emits every array-to-array assignment as an element-wise `for` loop, giving clang a basic block per assignment. Its value numbering scans them superlinearly, which makes one generated file the critical path of the whole build: `SimTop3.cpp` of the DefaultConfig XiangShan model costs **1318 s** at `-O3`, almost all in `GVNPass`, while no other file exceeds 244 s.

## Change

Emit one `memcpy` where a block copy is provably equivalent to the loop. Everything else keeps the existing emission, including the `memset` and per-element constant paths.

`ENode::compute` decides at the array reference itself and records its length on the `valInfo`; `arrayCopy` emits the block copy when the destination also walks one dimension. The decision never reads the generated text back — every operator builds a `valInfo` of its own, so a masked narrowing, a `pad` cast, a mux or a memory read all arrive with no record and fall through to the loop.

Three conditions make it equivalent:

- **Contiguity** — only the innermost dimension. Declared extents are rounded up to a power of two, so rows of a padded outer dimension are not adjacent. The count comes from `node->dimension`, not `sizeof`, keeping a prefix copy exact (10 elements into a `[16]` declaration).
- **No overlap** — a register splits into `X` and `X$NEXT`, so a self-copy reads current state and writes next state; arrays only survive `splitArray` once a runtime index reaches them; a wire copying from itself is a combinational loop.
- **Same element type** — a width change is lowered with a mask or a cast, which stops the rvalue being a bare reference. The boundary is the C type, not the FIRRTL width: `UInt<5>` and `UInt<8>` are both `uint8_t`.

## Results

Both trees generated from one frozen `SimTop.fir` by binaries built from the same worktree, clang 19.1.1, `-DGSIM -O3 -fbracket-depth=2048 -Wno-parentheses-equality`.

| | before | after |
|---|---|---|
| `SimTop3.cpp` | **1318.0 s** | **19.9 s** |
| slowest file overall | 1318.0 s | 250.1 s |
| whole model, compile CPU | 4529 s | 2943 s |

No observable change in simulation speed or binary size under the above mentioned param.

