### PR TITLE
perf(AST2Graph): drop the staging vector in ENode::getIdx

### DIFF
--- a/src/ENode.cpp
+++ b/src/ENode.cpp
@@ -308,20 +308,21 @@ if the lvalue is also an array(e.g. a[1], a defined as a[2][2]), return the rang
 */
 std::pair<int, int> ENode::getIdx(Node* node) {
   Assert(node->isArray(), "%s is not array", node->name.c_str());
-  std::vector<int>index;
-
+  /* The index children are read in order and never outlive the call, so they
+     are used in place. Staging them in a vector costs one heap round trip per
+     call, and array connections call this quadratically in Node::addArrayVal. */
   for (ENode* indexENode : child) {
     if (indexENode->opType != OP_INDEX_INT) return std::make_pair(-1, -1);
-    index.push_back(indexENode->values[0]);
   }
-  Assert(index.size() <= node->dimension.size(), "invalid index");
+  const size_t idxNum = child.size();
+  Assert(idxNum <= node->dimension.size(), "invalid index");
   int num = 1;
-  for (int i = (int)node->dimension.size() - 1; i >= (int)index.size(); i --) {
+  for (int i = (int)node->dimension.size() - 1; i >= (int)idxNum; i --) {
     num *= node->dimension[i];
   }
   int base = 0;
-  for (size_t i = 0; i < index.size(); i ++) {
-    base = base * node->dimension[i] + index[i];
+  for (size_t i = 0; i < idxNum; i ++) {
+    base = base * node->dimension[i] + child[i]->values[0];
   }
   return std::make_pair(base * num, (base + 1) * num - 1);
 }


### PR DESCRIPTION
## Problem

`ENode::getIdx` resolves the flat index range of an array reference. It stages
the index children into a heap allocated `std::vector<int>`, then reads them
back in the same order:

```cpp
std::vector<int> index;
for (ENode* indexENode : child) {
  if (indexENode->opType != OP_INDEX_INT) return std::make_pair(-1, -1);
  index.push_back(indexENode->values[0]);
}
...
base = base * node->dimension[i] + index[i];
```

The vector never outlives the call, so every call pays one allocation and one
release to hold one to three integers.

`Node::addArrayVal` calls `getIdx` once per existing entry of `assignTree` for
every new element wise connection, so the call count grows quadratically with
the number of assignments made to an array. On a XiangShan `SimTop` with 7.6M
nodes and 186281 split arrays, that is the dominant cost of the whole compiler
front end.

Profile of the `Init` stage on that design (`perf`, frame pointers, 37k samples):

| | share |
|---|---|
| `Init` as a share of the whole compile | 29.7% |
| elaboration traversal, as a share of `Init` | 88.1% |
| **`ENode::getIdx`, as a share of the traversal** | **50.3%** |
| `operator new` / `operator delete` in the traversal | 9.2% / 6.3% |

98% of the `getIdx` samples are reached from `Node::addArrayVal`.

## Change

Read the index children in place instead of staging them.

The early return keeps its position ahead of the bound assertion: the scan for
a non `OP_INDEX_INT` child still runs as a separate loop, so a reference that
bails out never reaches `Assert(idxNum <= node->dimension.size())`. Folding the
scan into the accumulation loop would have moved that assertion ahead of the
early return and could fire on input that returns cleanly today. `idxNum` is
only read once the scan has completed, which is exactly when `index.size() ==
child.size()` held before.

## Results

Three paired runs alternating on one machine, XiangShan `SimTop.fir`,
`--supernode-max-size=15 --cpp-max-size-KB=8192 --sep-mod=__DOT__
--sep-aggr=__DOT__`:

| run | before | after |
|---|---|---|
| 1 | 188.2 s | 147.7 s |
| 2 | 177.2 s | 146.8 s |
| 3 | 183.7 s | 142.9 s |
| **mean** | **183.0 s** | **145.8 s** (-20.4%) |

That is about 6% of the 639 s end to end compile. Both binaries link jemalloc,
so the saving is on top of a thread caching allocator rather than a consequence
of a slow one.

## Equivalence

`make fir-tests` passes.

The graph is unchanged. Every pass statistic printed for `rocket` and
`large-boom` is identical before and after, at every stage:

```
[removeDeadNodes] remove 75901 deadNodes (228927 -> 153026)
[aliasAnalysis]   remove ...
[cppEmitter]      define ... nodes ... superNodes
```

The emitted sources are reordered, because `Node::id` comes from an allocation
counter and `Node::prev` / `Node::next` are `std::set<Node*>` ordered by
address, so any change to the allocation pattern permutes the output. Comparing
whole models with node ids normalised and lines sorted:

| design | emitted lines | differing |
|---|---|---|
| large-boom | 741534 | **0** |
| rocket | 256978 | 24 |

The 24 rocket lines are 12 extra `if (...) { ... }` guards, no deletions. They
come from `graph::activateNext`:

```cpp
curMask = activeSet2bitMap(nextNodeId, bitMapInfo, node->super->cppId);
opt = ((ACTIVE_MASK(curMask) != 0) + bitMapInfo.size()) <= 3;
```

`bitMapInfo.size()` counts the 64 bit words spanned by a node's activation ids.
Reordering spreads twelve of those sets across one extra word, so `opt` turns
off and they emit the guarded form instead of the branchless one. Both encode
the same activation. This is a code shape difference that any reordering can
produce, not a semantic one, which is consistent with large-boom showing none.

