### PR TITLE
fix(codegen): define dynamic right-shift overshifts

### DIFF
--- a/src/instsGenerator.cpp
+++ b/src/instsGenerator.cpp
@@ -739,11 +739,25 @@ valInfo* ENode::instsDshr(Node* node, std::string lvalue, bool isRoot) {
       ret->opNum = ChildInfo(0, opNum) + 1;
     }
   } else {
-    ret->valStr = format("((%s%s %s) & %s)",
-                         Cast(ChildInfo(0, width), Child(0, sign)).c_str(),
-                         ChildInfo(0, valStr).c_str(),
-                         shiftBits(ChildInfo(1, valStr), ShiftDir::Right).c_str(),
-                         bitMask(width).c_str());
+    const std::string value = format("%s%s",
+                                     Cast(ChildInfo(0, width), Child(0, sign)).c_str(),
+                                     ChildInfo(0, valStr).c_str());
+    const std::string shifted = format("((%s %s) & %s)", value.c_str(),
+                                       shiftBits(ChildInfo(1, valStr), ShiftDir::Right).c_str(),
+                                       bitMask(width).c_str());
+    const int shiftWidth = ChildInfo(1, width);
+    const bool mayOvershift = shiftWidth >= 63 ||
+      (uint64_t{1} << shiftWidth) > static_cast<uint64_t>(ChildInfo(0, width));
+    if (mayOvershift) {
+      const std::string overshift = Child(0, sign)
+        ? format("((%s < 0) ? %s : 0)", value.c_str(), bitMask(width).c_str())
+        : "0";
+      ret->valStr = format("((%s >= %d) ? %s : %s)",
+                           ChildInfo(1, valStr).c_str(), ChildInfo(0, width),
+                           overshift.c_str(), shifted.c_str());
+    } else {
+      ret->valStr = shifted;
+    }
     ret->opNum = ChildInfo(0, opNum) + ChildInfo(1, opNum) + 1;
   }
   if (ChildInfo(0, typeWidth) > BASIC_WIDTH) {

--- a/test/README.md
+++ b/test/README.md
@@ -3,6 +3,8 @@
 - Any `*.fir` file in this directory is auto-discovered by `make fir-tests` and by the GitHub CI `fir-regression` job.
 - A same-name `*.cpp` file is compiled with the generated model and run under
   AddressSanitizer and UndefinedBehaviorSanitizer.
+- dshr-overshift.fir: Checks FIRRTL-defined dynamic right shifts at and beyond
+  the operand width for both unsigned and signed values.
 - repro-usefulreset.fir: Minimized FIR reproducer for GSIM issue #106, used to guard against ConstantAnalysis hangs and OOM regressions.
 - signed-node-shr.fir: Checks constant propagation of a signed right shift
   whose operand is a node reference.

--- a/test/dshr-overshift.cpp
+++ b/test/dshr-overshift.cpp
@@ -1,0 +1,34 @@
+#include <cstdio>
+
+#include "DshrOvershift.h"
+
+int main() {
+  SDshrOvershift dut;
+  const unsigned _BitInt(128) ones = (unsigned _BitInt(128))-1;
+
+  dut.set_unsigned_in(ones);
+  dut.set_signed_in(-2);
+
+  dut.set_shift(127);
+  dut.step();
+  if (dut.get_unsigned_out() != 1) return 1;
+  if (dut.get_signed_out() != -1) return 2;
+
+  dut.set_shift(128);
+  dut.step();
+  if (dut.get_unsigned_out() != 0) return 3;
+  if (dut.get_signed_out() != -1) return 4;
+
+  dut.set_shift(255);
+  dut.step();
+  if (dut.get_unsigned_out() != 0) return 5;
+  if (dut.get_signed_out() != -1) return 6;
+
+  dut.set_signed_in(2);
+  dut.set_shift(128);
+  dut.step();
+  if (dut.get_signed_out() != 0) return 7;
+
+  std::puts("dshr overshift: PASS");
+  return 0;
+}

--- a/test/dshr-overshift.fir
+++ b/test/dshr-overshift.fir
@@ -1,0 +1,11 @@
+FIRRTL version 3.3.0
+circuit DshrOvershift :
+  module DshrOvershift :
+    input unsigned_in : UInt<128>
+    input signed_in : SInt<128>
+    input shift : UInt<8>
+    output unsigned_out : UInt<128>
+    output signed_out : SInt<128>
+
+    connect unsigned_out, dshr(unsigned_in, shift)
+    connect signed_out, dshr(signed_in, shift)


### PR DESCRIPTION
FIRRTL defines dynamic right shifts at or beyond the input width. Unsigned values must become zero, while signed values must become all zeroes or all ones according to the input sign.

GSIM emitted these operations as native C++ shifts. Shifting a 128-bit value by 128 is undefined behavior, and Clang kept the source value instead of producing zero. In XiangShan's VPerm tail-mask path, this changed a vector register write and caused difftest to fail at instruction 51,574.

Guard dynamic right shifts when the shift input can represent an overshift. Return zero for unsigned values and a sign-filled result for signed values before evaluating the native shift expression.

The regression uses a minimal UInt<128>/SInt<128> model and checks shift amounts 127, 128, and 255. The FIR test runner also compiles and executes same-name C++ harnesses with ASan and UBSan.