### PR TITLE
fix(constant): shift the signed source operand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,6 +220,7 @@ FIR_TEST_OUTPUT_DIR ?= $(BUILD_DIR)/fir-tests
 FIR_TEST_CASES ?= $(basename $(notdir $(wildcard $(FIR_TEST_INPUT_DIR)/*.fir)))
 FIR_TEST_TIMEOUT ?=
 FIR_TEST ?=
+FIR_TEST_CXXFLAGS ?= --std=c++20 -O1 -fsanitize=address,undefined -fno-sanitize-recover=all
 FIR_TEST_TIMEOUT_PREFIX = $(if $(strip $(FIR_TEST_TIMEOUT)),timeout $(FIR_TEST_TIMEOUT),)
 FIR_TEST_TARGETS = $(addprefix $(FIR_TEST_OUTPUT_DIR)/,$(addsuffix /.done,$(FIR_TEST_CASES)))
 
@@ -233,10 +234,18 @@ compile: $(GEN_CPP_DIR)/$(NAME)0.cpp
 
 .PHONY: compile
 
-$(FIR_TEST_OUTPUT_DIR)/%/.done: $(FIR_TEST_INPUT_DIR)/%.fir $(GSIM_BIN)
+.SECONDEXPANSION:
+$(FIR_TEST_OUTPUT_DIR)/%/.done: $(FIR_TEST_INPUT_DIR)/%.fir $(GSIM_BIN) $$(wildcard $$(FIR_TEST_INPUT_DIR)/$$*.cpp)
 	@mkdir -p $(@D)
 	set -o pipefail && $(TIME) $(FIR_TEST_TIMEOUT_PREFIX) $(GSIM_BIN) --dir $(@D) \
 		$(GSIM_FLAGS_EXTRA) $< | tee $(@D)/gsim.log
+	@if [[ -f "$(FIR_TEST_INPUT_DIR)/$*.cpp" ]]; then \
+		set -e; \
+		echo "+ CXX/RUN $*"; \
+		$(CXX) $(FIR_TEST_CXXFLAGS) -I$(@D) $(@D)/*.cpp \
+			$(FIR_TEST_INPUT_DIR)/$*.cpp -o $(@D)/runtime-test; \
+		$(FIR_TEST_TIMEOUT_PREFIX) $(@D)/runtime-test; \
+	fi
 	@touch $@
 
 run-fir-test: $(GSIM_BIN)

--- a/src/opFuncs.cpp
+++ b/src/opFuncs.cpp
@@ -33,7 +33,7 @@ void u_shl(mpz_t& dst, mpz_t& src, mp_bitcnt_t bitcnt, unsigned long n) { mpz_mu
 void u_shr(mpz_t& dst, mpz_t& src, mp_bitcnt_t bitcnt, unsigned long n) { mpz_tdiv_q_2exp(dst, src, n); }
 void s_shr(mpz_t& dst, mpz_t& src, mp_bitcnt_t bitcnt, unsigned long n) {
   if (mpz_cmp_ui(src, 0) < 0) {
-    mpz_fdiv_q_2exp(dst, dst, n);
+    mpz_fdiv_q_2exp(dst, src, n);
   } else {
     mpz_tdiv_q_2exp(dst, src, n);
   }

--- a/test/README.md
+++ b/test/README.md
@@ -1,4 +1,8 @@
 # Test Inputs
 
 - Any `*.fir` file in this directory is auto-discovered by `make fir-tests` and by the GitHub CI `fir-regression` job.
+- A same-name `*.cpp` file is compiled with the generated model and run under
+  AddressSanitizer and UndefinedBehaviorSanitizer.
 - repro-usefulreset.fir: Minimized FIR reproducer for GSIM issue #106, used to guard against ConstantAnalysis hangs and OOM regressions.
+- signed-node-shr.fir: Checks constant propagation of a signed right shift
+  whose operand is a node reference.

--- a/test/signed-node-shr.cpp
+++ b/test/signed-node-shr.cpp
@@ -1,0 +1,14 @@
+#include <cstdio>
+
+#include "SignedNodeShr.h"
+
+int main() {
+  SSignedNodeShr dut;
+  dut.step();
+
+  const signed _BitInt(7) shifted = dut.get_shifted();
+  if (shifted != -3) return 1;
+
+  std::puts("signed node shr: PASS");
+  return 0;
+}

--- a/test/signed-node-shr.fir
+++ b/test/signed-node-shr.fir
@@ -1,0 +1,8 @@
+FIRRTL version 3.3.0
+circuit SignedNodeShr :
+  module SignedNodeShr :
+    output shifted : SInt<7>
+
+    wire negative : SInt<8>
+    connect negative, SInt<8>(-5)
+    connect shifted, shr(negative, 1)


### PR DESCRIPTION
s_shr() selected floor division for a negative source but passed dst as both the destination and input to mpz_fdiv_q_2exp(). During constant propagation dst starts at zero, so a signed right shift whose operand came through a node reference could fold to zero instead of the shifted source value.

Pass src to mpz_fdiv_q_2exp(), matching the positive path and the function contract.

The regression assigns SInt<8>(-5) through a wire before shr(..., 1) and requires the folded result to be -3.