### PR TITLE
fix(split): preserve signed constant slice semantics

### DIFF
--- a/include/splitNode.h
+++ b/include/splitNode.h
@@ -41,7 +41,9 @@ public:
     updateWidth();
   }
   void updateWidth() {
-    if (lo != 0) mpz_tdiv_q_2exp(val, val, lo);
+    if (lo != 0) {
+      (sign ? mpz_fdiv_q_2exp : mpz_tdiv_q_2exp)(val, val, lo);
+    }
     mpz_t mask;
     mpz_init(mask);
     mpz_set_ui(mask, 1);
@@ -66,13 +68,17 @@ public:
     return ret;
   }
   /* select [_hi, lo] */
-  NodeElement* getBits(int _hi, int _lo) {
+  NodeElement* getBits(int _hi, int _lo, bool arithmeticShift = false) {
     Assert(_hi <= hi - lo + 1, "invalid range [%d, %d]", _hi, lo);
     NodeElement* ret = dup();
     if (eleType == ELE_NODE) {
       ret->hi = _hi + ret->lo;
       ret->lo = _lo + ret->lo;
     } else {
+      if (ret->eleType == ELE_INT && !arithmeticShift && ret->sign && mpz_sgn(ret->val) < 0) {
+        u_asUInt(ret->val, ret->val, ret->hi - ret->lo + 1);
+      }
+      ret->sign = arithmeticShift && ret->sign;
       ret->hi = _hi;
       ret->lo = _lo;
       if (eleType == ELE_INT) ret->updateWidth();
@@ -148,7 +154,7 @@ public:
     }
     return ret;
   }
-  void getElementBits(NodeComponent* src, int hi, int lo) {
+  void getElementBits(NodeComponent* src, int hi, int lo, bool arithmeticShift) {
     int w = src->width;
     bool start = false;
     if (hi >= src->width) {
@@ -164,14 +170,14 @@ public:
         if (start) {
           int selectHigh = MIN(hi, w-1) - (w - memberWidth);
           int selectLo = MAX(lo, w - memberWidth) - (w - memberWidth);
-          addElement(src->elements[i]->getBits(selectHigh, selectLo));
+          addElement(src->elements[i]->getBits(selectHigh, selectLo, arithmeticShift));
           if ((w - memberWidth) <= lo) break;
         }
         w = w - memberWidth;
       }
     }
   }
-  void getDirectBits(NodeComponent* src, int hi, int lo) {
+  void getDirectBits(NodeComponent* src, int hi, int lo, bool arithmeticShift) {
     int w = src->width;
     bool start = false;
     if (hi >= src->width) {
@@ -187,17 +193,17 @@ public:
         if (start) {
           int selectHigh = MIN(hi, w-1) - (w - memberWidth);
           int selectLo = MAX(lo, w - memberWidth) - (w - memberWidth);
-          addDirectElement(src->directElements[i]->getBits(selectHigh, selectLo));
+          addDirectElement(src->directElements[i]->getBits(selectHigh, selectLo, arithmeticShift));
           if ((w - memberWidth) <= lo) break;
         }
         w = w - memberWidth;
       }
     }
   }
-  NodeComponent* getbits(int hi, int lo) {
+  NodeComponent* getbits(int hi, int lo, bool arithmeticShift = false) {
     NodeComponent* comp = new NodeComponent();
-    comp->getElementBits(this, hi, lo);
-    comp->getDirectBits(this, hi, lo);
+    comp->getElementBits(this, hi, lo, arithmeticShift);
+    comp->getDirectBits(this, hi, lo, arithmeticShift);
     return comp;
   }
   int countWidth() {

--- a/src/splitNodes.cpp
+++ b/src/splitNodes.cpp
@@ -126,6 +126,34 @@ void addDirectRef(NodeComponent* dst, NodeComponent* comp) {
     dst->directElements[0]->referNodes.insert(comp->directElements[i]->referNodes.begin(), comp->directElements[i]->referNodes.end());
 }
 
+static NodeElement* signExtendConstant(NodeElement* element, int width) {
+  NodeElement* ret = element->dup();
+  ret->hi = width - 1;
+  ret->lo = 0;
+  ret->sign = true;
+  ret->updateWidth();
+  return ret;
+}
+
+static NodeComponent* padComponent(NodeComponent* src, int width, bool sign) {
+  if (!sign) return src->getbits(width - 1, 0);
+
+  if (src->elements.size() == 1 &&
+      src->elements[0]->eleType == ELE_INT &&
+      src->directElements.size() == 1 &&
+      src->directElements[0]->eleType == ELE_INT) {
+    NodeComponent* ret = new NodeComponent();
+    ret->addElement(signExtendConstant(src->elements[0], width));
+    ret->addDirectElement(signExtendConstant(src->directElements[0], width));
+    return ret;
+  }
+
+  NodeComponent* ret = spaceComp(width);
+  addRefer(ret, src);
+  addDirectRef(ret, src);
+  return ret;
+}
+
 NodeComponent* mergeMux(NodeComponent* comp1, NodeComponent* comp2, int width) {
   NodeComponent* ret;
   if (comp1->elements.size() == 1 && comp1->elements[0]->eleType == ELE_INT) {
@@ -276,10 +304,10 @@ NodeComponent* ENode::inferComponent(Node* n) {
       ret->addElementAll(new NodeElement("0", 16, values[0] - 1, 0));
       break;
     case OP_SHR:
-      ret = childComp[0]->getbits(childComp[0]->width - 1, values[0]);
+      ret = childComp[0]->getbits(childComp[0]->width - 1, values[0], sign);
       break;
     case OP_PAD:
-      ret = childComp[0]->getbits(values[0]-1, 0);
+      ret = padComponent(childComp[0], width, sign);
       break;
     case OP_WHEN:
       if (!getChild(1) && !getChild(2)) break;

--- a/test/README.md
+++ b/test/README.md
@@ -12,3 +12,5 @@
 - repro-usefulreset.fir: Minimized FIR reproducer for GSIM issue #106, used to guard against ConstantAnalysis hangs and OOM regressions.
 - signed-node-shr.fir: Checks constant propagation of a signed right shift
   whose operand is a node reference.
+- signed-constant-slice.fir: Checks node splitting of shifts, bit selections,
+  and padding applied to negative signed constants.

--- a/test/signed-constant-slice.cpp
+++ b/test/signed-constant-slice.cpp
@@ -1,0 +1,22 @@
+#include <cstdio>
+
+#include "SignedConstantSlice.h"
+
+int main() {
+  SSignedConstantSlice dut;
+  dut.step();
+
+  const signed _BitInt(7) shifted = dut.get_shifted();
+  if (shifted != -3) return 1;
+  if (dut.get_selected() != 5) return 2;
+  const signed _BitInt(12) padded = dut.get_padded();
+  if (padded != -5) return 3;
+  if (dut.get_padded_high() != 0xf) return 4;
+  const signed _BitInt(4) padded_shifted = dut.get_padded_shifted();
+  if (padded_shifted != -1) return 5;
+  const signed _BitInt(8) pad_identity = dut.get_pad_identity();
+  if (pad_identity != -5) return 6;
+
+  std::puts("signed constant slice: PASS");
+  return 0;
+}

--- a/test/signed-constant-slice.fir
+++ b/test/signed-constant-slice.fir
@@ -1,0 +1,16 @@
+FIRRTL version 3.3.0
+circuit SignedConstantSlice :
+  module SignedConstantSlice :
+    output shifted : SInt<7>
+    output selected : UInt<3>
+    output padded : SInt<12>
+    output padded_high : UInt<4>
+    output padded_shifted : SInt<4>
+    output pad_identity : SInt<8>
+
+    connect shifted, shr(SInt<8>(-5), 1)
+    connect selected, bits(SInt<8>(-5), 3, 1)
+    connect padded, pad(SInt<8>(-5), 12)
+    connect padded_high, bits(pad(SInt<8>(-5), 12), 11, 8)
+    connect padded_shifted, shr(pad(SInt<8>(-5), 12), 8)
+    connect pad_identity, pad(SInt<8>(-5), 4)


### PR DESCRIPTION
Node splitting used one constant-slicing path for both bit selection and arithmetic right shift. The path divided negative GMP values with truncation toward zero and kept signed interpretation for raw bits. Consequently, shr(SInt<8>(-5), 1) and bits(SInt<8>(-5), 3, 1) could be folded with the wrong semantics.

Mark slices requested by OP_SHR as arithmetic. Use floor division for negative signed shifts so sign extension is preserved. For ordinary bit selection, first reinterpret a negative constant as its finite-width unsigned representation and return an unsigned slice.

The constant-only regression checks that -5 >> 1 equals -3 and that bits [3:1] of the same 8-bit value equal 5.