### PR TITLE
fix(opt): slice cat constants at the correct boundary

### DIFF
--- a/src/patternDetect.cpp
+++ b/src/patternDetect.cpp
@@ -86,7 +86,7 @@ bool checkPattern2(Node *node) {
         int lwidth = lsignal->width;
         int rwidth = rsignal->width;
         if(catNode->opType == OP_CAT) {
-            BITS_mpz(constant1, constant, lwidth + rwidth, rwidth + 1);
+            BITS_mpz(constant1, constant, lwidth + rwidth - 1, rwidth);
             BITS_mpz(constant2, constant, rwidth - 1, 0);
             ret = true;
         } else if(catNode->opType == OP_OR) {

--- a/test/README.md
+++ b/test/README.md
@@ -5,6 +5,8 @@
   AddressSanitizer and UndefinedBehaviorSanitizer.
 - dshr-overshift.fir: Checks FIRRTL-defined dynamic right shifts at and beyond
   the operand width for both unsigned and signed values.
+- cat-eq-constant.fir: Checks constant slicing in the
+  `cat(lhs, rhs) == constant` optimization.
 - repro-usefulreset.fir: Minimized FIR reproducer for GSIM issue #106, used to guard against ConstantAnalysis hangs and OOM regressions.
 - signed-node-shr.fir: Checks constant propagation of a signed right shift
   whose operand is a node reference.

--- a/test/cat-eq-constant.cpp
+++ b/test/cat-eq-constant.cpp
@@ -1,0 +1,25 @@
+#include <cstdio>
+
+#include "CatEqConstant.h"
+
+int main() {
+  SCatEqConstant dut;
+
+  dut.set_lhs(0xa);
+  dut.set_rhs(0xb);
+  dut.step();
+  if (dut.get_out() != 1) return 1;
+  if (dut.get_inverted() != 0) return 2;
+
+  dut.set_lhs(0x5);
+  dut.step();
+  if (dut.get_out() != 0) return 3;
+
+  dut.set_lhs(0xa);
+  dut.set_rhs(0xa);
+  dut.step();
+  if (dut.get_out() != 0) return 4;
+
+  std::puts("cat equality constant: PASS");
+  return 0;
+}

--- a/test/cat-eq-constant.fir
+++ b/test/cat-eq-constant.fir
@@ -1,0 +1,12 @@
+FIRRTL version 3.3.0
+circuit CatEqConstant :
+  module CatEqConstant :
+    input lhs : UInt<4>
+    input rhs : UInt<4>
+    output out : UInt<1>
+    output inverted : UInt<1>
+
+    wire matched : UInt<1>
+    connect matched, eq(cat(lhs, rhs), UInt<8>(0hab))
+    connect out, matched
+    connect inverted, not(matched)


### PR DESCRIPTION
The pattern-2 optimization rewrites equality tests over cat(lhs, rhs) into separate comparisons. It extracted the upper constant with [lwidth + rwidth : rwidth + 1], which is off by one at both ends. The generated comparison skipped bit rwidth and sampled one bit above the concatenation, so valid inputs could evaluate incorrectly.

Slice the upper field at [lwidth + rwidth - 1 : rwidth], matching the exact layout of cat(lhs, rhs).

The regression compares a minimal 4-bit concatenation with 0xab. Its runtime harness checks the matching input and mismatches in each operand, while the FIR input guarantees that pattern 2 is exercised.