### PR TITLE
fix(codegen): guard dynamic vector indices

### DIFF
--- a/include/ExpTree.h
+++ b/include/ExpTree.h
@@ -224,7 +224,7 @@ public:
   void inferWidth();
   void usedBitWithFixRoot(int width);
   void clearWidth();
-  valInfo* compute(Node* n, std::string lvalue, bool isRoot);
+  valInfo* compute(Node* n, std::string lvalue, bool isRoot, bool isLvalue = false);
   valInfo* computeConstant(Node* node, bool isLvalue);
   void passWidthToChild();
   void updateWidth();

--- a/include/valInfo.h
+++ b/include/valInfo.h
@@ -30,6 +30,7 @@ public:
   int end = -1;
   std::vector<valInfo*> memberInfo;
   bool sameConstant = false;
+  std::string boundsCheck;
   /* Length of the bare array reference valStr was built from, zero when valStr
      is anything else. Placed here to fit existing padding. */
   uint32_t arrayRefLen = 0;
@@ -86,6 +87,7 @@ public:
     ret->typeWidth = typeWidth;
     ret->sign = sign;
     ret->consLength = consLength;
+    ret->boundsCheck = boundsCheck;
     mpz_set(ret->assignmentCons, assignmentCons);
     ret->sameConstant = sameConstant;
     ret->directUpdate = directUpdate;

--- a/src/instsGenerator.cpp
+++ b/src/instsGenerator.cpp
@@ -1479,7 +1479,7 @@ valInfo* allocNodeInfo(Node* n) {
 }
 
 /* compute enode */
-valInfo* ENode::compute(Node* n, std::string lvalue, bool isRoot) {
+valInfo* ENode::compute(Node* n, std::string lvalue, bool isRoot, bool isLvalue) {
   if (computeInfo) return computeInfo;
   if (width == 0 && !IS_INVALID_LVALUE(lvalue)) {
     computeInfo = new valInfo();
@@ -1492,8 +1492,34 @@ valInfo* ENode::compute(Node* n, std::string lvalue, bool isRoot) {
   if (nodePtr) {
     if (nodePtr->isArray()) {
       computeInfo = allocNodeInfo(nodePtr);
-      for (ENode* childENode : child)
+      std::string boundsCheck;
+      const bool isPartialRef = getChildNum() < nodePtr->dimension.size();
+      for (size_t i = 0; i < child.size(); i++) {
+        ENode* childENode = child[i];
+        if (childENode->opType == OP_INDEX) {
+          const std::string& index = childENode->getChild(0)->computeInfo->valStr;
+          const int indexWidth = childENode->getChild(0)->computeInfo->width;
+          const bool mayBeOutOfBounds = indexWidth >= 63 ||
+            (uint64_t{1} << indexWidth) > static_cast<uint64_t>(nodePtr->dimension[i]);
+          if (mayBeOutOfBounds) {
+            if (!boundsCheck.empty()) boundsCheck += " && ";
+            boundsCheck += format("(%s < %d)", index.c_str(), nodePtr->dimension[i]);
+          }
+          if (mayBeOutOfBounds && !isLvalue && isPartialRef) {
+            computeInfo->valStr += format("[((%s < %d) ? %s : 0)]",
+                                          index.c_str(), nodePtr->dimension[i], index.c_str());
+            continue;
+          }
+        }
         computeInfo->valStr += childENode->computeInfo->valStr;
+      }
+      if (!boundsCheck.empty()) {
+        computeInfo->boundsCheck = boundsCheck;
+        if (!isLvalue && getChildNum() == nodePtr->dimension.size()) {
+          computeInfo->valStr = format("((%s) ? %s : 0)",
+                                       boundsCheck.c_str(), computeInfo->valStr.c_str());
+        }
+      }
       int beg, end;
       std::tie(beg, end) = getIdx(nodePtr);
       computeInfo->beg = beg;
@@ -1727,8 +1753,11 @@ void StmtNode::compute(std::vector<InstInfo>& insts, std::set<InstInfo> assign_i
     case OP_STMT_NODE: {
       Assert(!isENode, "invalid stmt node\n");
       Node* node = tree->getlval()->getNode();
-      valInfo* linfo = tree->getlval()->compute(node, INVALID_LVALUE, false);
+      valInfo* linfo = tree->getlval()->compute(node, INVALID_LVALUE, false, true);
       valInfo* rinfo = tree->getRoot()->compute(node, linfo->valStr, true);
+      if (!linfo->boundsCheck.empty()) {
+        insts.emplace_back(format("if (%s) {", linfo->boundsCheck.c_str()), SUPER_INFO_IF);
+      }
       if (rinfo->status == VAL_FINISH || node->type == NODE_SPECIAL) { // printf / assert
         insts.emplace_back(rinfo->valStr);
       } else if (rinfo->status == VAL_INVALID) {
@@ -1758,6 +1787,9 @@ void StmtNode::compute(std::vector<InstInfo>& insts, std::set<InstInfo> assign_i
           if (assign_insts) assign_insts[1].emplace(SUPER_INFO_ASSIGN_END, belong);
           else insts.emplace_back(SUPER_INFO_ASSIGN_END, belong);
         }
+      }
+      if (!linfo->boundsCheck.empty()) {
+        insts.emplace_back("}", SUPER_INFO_DEDENT);
       }
       break;
     }

--- a/test/README.md
+++ b/test/README.md
@@ -5,6 +5,8 @@
   AddressSanitizer and UndefinedBehaviorSanitizer.
 - dshr-overshift.fir: Checks FIRRTL-defined dynamic right shifts at and beyond
   the operand width for both unsigned and signed values.
+- dynamic-vector-index.fir: Checks in-bounds reads plus deterministic,
+  memory-safe out-of-bounds reads and writes through dynamic vector indices.
 - repro-usefulreset.fir: Minimized FIR reproducer for GSIM issue #106, used to guard against ConstantAnalysis hangs and OOM regressions.
 - signed-node-shr.fir: Checks constant propagation of a signed right shift
   whose operand is a node reference.

--- a/test/dynamic-vector-index.cpp
+++ b/test/dynamic-vector-index.cpp
@@ -1,0 +1,42 @@
+#include <cstdio>
+
+#include "DynamicVectorIndex.h"
+
+int main() {
+  SDynamicVectorIndex dut;
+
+  dut.set_write_enable(0);
+  dut.set_read_index(1);
+  dut.step();
+  if (dut.get_selected() != 0x22) return 1;
+  if (dut.get_copied_0() != 0x50) return 2;
+  if (dut.get_copied_1() != 0x51) return 3;
+
+  dut.set_read_index(15);
+  dut.step();
+  if (dut.get_selected() != 0) return 4;
+  if (dut.get_copied_0() != 0x40) return 5;
+  if (dut.get_copied_1() != 0x41) return 6;
+
+  dut.set_write_enable(1);
+  dut.set_read_index(1);
+  dut.set_write_index(1);
+  dut.step();
+  if (dut.get_selected() != 0x99) return 7;
+  if (dut.get_element_1() != 0x99) return 8;
+  if (dut.get_matrix_1_0() != 0x61) return 9;
+  if (dut.get_matrix_1_1() != 0x62) return 10;
+
+  dut.set_write_index(15);
+  dut.step();
+  if (dut.get_element_0() != 0x11) return 11;
+  if (dut.get_element_1() != 0x22) return 12;
+  if (dut.get_element_2() != 0x33) return 13;
+  if (dut.get_matrix_0_0() != 0x40) return 14;
+  if (dut.get_matrix_0_1() != 0x41) return 15;
+  if (dut.get_matrix_1_0() != 0x50) return 16;
+  if (dut.get_matrix_1_1() != 0x51) return 17;
+
+  std::puts("dynamic vector index: PASS");
+  return 0;
+}

--- a/test/dynamic-vector-index.fir
+++ b/test/dynamic-vector-index.fir
@@ -1,0 +1,47 @@
+FIRRTL version 3.3.0
+circuit DynamicVectorIndex :
+  module DynamicVectorIndex :
+    input read_index : UInt<4>
+    input write_index : UInt<4>
+    input write_enable : UInt<1>
+    output selected : UInt<8>
+    output element_0 : UInt<8>
+    output element_1 : UInt<8>
+    output element_2 : UInt<8>
+    output copied_0 : UInt<8>
+    output copied_1 : UInt<8>
+    output matrix_0_0 : UInt<8>
+    output matrix_0_1 : UInt<8>
+    output matrix_1_0 : UInt<8>
+    output matrix_1_1 : UInt<8>
+
+    wire values : UInt<8>[3]
+    connect values[0], UInt<8>(0h11)
+    connect values[1], UInt<8>(0h22)
+    connect values[2], UInt<8>(0h33)
+    when write_enable :
+      connect values[write_index], UInt<8>(0h99)
+
+    wire matrix : UInt<8>[2][2]
+    connect matrix[0][0], UInt<8>(0h40)
+    connect matrix[0][1], UInt<8>(0h41)
+    connect matrix[1][0], UInt<8>(0h50)
+    connect matrix[1][1], UInt<8>(0h51)
+    wire row : UInt<8>[2]
+    connect row[0], UInt<8>(0h61)
+    connect row[1], UInt<8>(0h62)
+    when write_enable :
+      connect matrix[write_index], row
+    wire copied : UInt<8>[2]
+    connect copied, matrix[read_index]
+
+    connect selected, values[read_index]
+    connect element_0, values[0]
+    connect element_1, values[1]
+    connect element_2, values[2]
+    connect copied_0, copied[0]
+    connect copied_1, copied[1]
+    connect matrix_0_0, matrix[0][0]
+    connect matrix_0_1, matrix[0][1]
+    connect matrix_1_0, matrix[1][0]
+    connect matrix_1_1, matrix[1][1]


### PR DESCRIPTION
Dynamic FIRRTL vector references were emitted as direct C++ array subscripts. An out-of-range index therefore performed an actual C++ out-of-bounds read or write. The undefined behavior could corrupt state or fail only under a sanitizer instead of producing a stable FIRRTL indeterminate value.

This also affected partial references such as matrix[index], where an invalid outer index was used before the generated element-copy loop.

Track a bounds predicate while lowering a vector reference. Scalar out-of-range reads return a deterministic zero, partial reads select subarray zero, and out-of-range writes become conditional no-ops. Skip the predicate when the index width proves every value is valid.

The regression uses one- and two-dimensional vectors to cover valid reads, invalid scalar and partial reads, valid writes, and invalid writes. The runtime harness executes every case under ASan and UBSan.